### PR TITLE
(#RICEMAN) gen9tradeabilities: Update Tradeabilities banlist - remove Raging Bolt

### DIFF
--- a/formats/gen9tradeabilities.tour
+++ b/formats/gen9tradeabilities.tour
@@ -1,5 +1,5 @@
-/tour new [Gen 9] Trademarked,elim,,,[Gen 9] Tradeabilities
-/tour rules [Gen 9] Pokebilities, *Burning Bulwark, *Endure, *Glare, *Pain Split, *Toxic, -Recycle + Eject Button, -Recycle + Eject Pack, -Recycle + Red Card, -Azumarill, +Annihilape, +Iron Bundle, +Ogerpon-Hearthflame, +Regieleki, +Spectrier, +Urshifu-Base
+/tour new [Gen 9] Trademarked,elim,,, [Gen 9] Tradeabilities
+/tour rules [Gen 9] Pokebilities, *Burning Bulwark, *Endure, *Glare, *Pain Split, *Toxic, -Recycle + Eject Button, -Recycle + Eject Pack, -Recycle + Red Card, *Recover + Roost + Slack Off + Soft-Boiled > 1, -Regenerator > 2, -Azumarill, -Raging Bolt, +Annihilape, +Iron Bundle, +Ogerpon-Hearthflame, +Regieleki, +Spectrier, +Urshifu-Base
 /tour autostart 10
-/tour autodq 7
-/wall **Hub: https://www.smogon.com/forums/threads/om-mashup-megathread.3711916/post-10133275**
+/tour autodq 10
+/wall https://www.smogon.com/forums/threads/om-mashup-megathread.3711916/post-10133275


### PR DESCRIPTION
#RICEMAN: "Update Tradeabilities banlist - remove Raging Bolt"

Created via Iolanthe on Tue, 11 Jun 2024 00:25:22 GMT.