### PR TITLE
(#Clas) gen9stabmnm: executive order restricts + code cleanup but actually correctly (ceaseless, denergy, eshot, jpunch, surging, freeing melo)

### DIFF
--- a/formats/gen9stabmnm.tour
+++ b/formats/gen9stabmnm.tour
@@ -1,5 +1,5 @@
-/tour new [Gen 9] Mix and Mega, Elimination,,,[Gen 9] STABmons n Mega
-/tour rules STABmons Move Legality, +Gholdengo, +Kilowattrel, +Urshifu-Rapid-Strike, +Zapdos,*Meloetta, *Ursaluna-Base, *Ursaluna-Blood-Moon, *Walking Wake, *Zoroark-Hisui, -Arceus, -Enamorus-Base, -Komala, -King's Rock, *Acupressure, *Astral Barrage, *Belly Drum,*Blood Moon,*Boomburst, *Clangorous Soul, *Dire Claw, *Extreme Speed, *Fillet Away,*Gigaton Hammer, *Last Respects, *No Retreat,*Power Trip, *Revival Blessing, *Shed Tail, *Shell Smash, *Shift Gear, *Triple Arrows, *V-create, *Victory Dance, *Wicked Blow
+/tour new [Gen 9] Mix and Mega, Elimination,,,[Gen 9] STABmons Mix and Mega
+/tour rules STABmons Move Legality, +Gholdengo, *Dragapult, *Ursaluna, *Walking Wake, *Zoroark-Hisui, -Arceus, -Enamorus-Base, -Komala, -King's Rock, *Acupressure, *Astral Barrage, *Belly Drum, *Blood Moon, *Boomburst, *Ceasless Edge, *Clangorous Soul, *Dire Claw, *Dragon Energy, *Extreme Speed, *Fillet Away,*Gigaton Hammer, *Jet Punch, *Last Respects, *Lumina Crash, *No Retreat,*Power Trip, *Rage Fist,*Revival Blessing, *Shed Tail, *Shell Smash, *Shift Gear, *Surging Strikes, *Triple Arrows, *V-create, *Victory Dance, *Wicked Blow
 /tour autostart 7
 /tour autodq 4
 /wall Hub link: https://www.smogon.com/forums/threads/om-mashup-megathread.3711916/#post-9422888


### PR DESCRIPTION
#Clas: "executive order restricts + code cleanup but actually correctly (ceaseless, denergy, eshot, jpunch, surging, freeing melo)"

Created via Iolanthe on Sun, 09 Feb 2025 00:01:59 GMT.